### PR TITLE
Fix StartScreen player count validation

### DIFF
--- a/src/StartScreen.tsx
+++ b/src/StartScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { MIN_PLAYERS, MAX_PLAYERS } from './constants';
 
 interface StartScreenProps {
   onStartGame: (numPlayers: number) => void;
@@ -30,7 +31,7 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         <h1 className="title">Pictophone</h1>
       </div>
       <label htmlFor="num-players-input" className="num-players-label">
-        Number of players (1 to 20):
+        Number of players ({MIN_PLAYERS} to {MAX_PLAYERS}):
       </label>
       <input
         id="num-players-input"

--- a/src/StartScreen.tsx
+++ b/src/StartScreen.tsx
@@ -11,7 +11,7 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
   const handleNumPlayersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     const num = parseInt(value, 10);
-    if (!isNaN(num) && num >= 1 && num <= 20) {
+    if (!isNaN(num) && num >= MIN_PLAYERS && num <= MAX_PLAYERS) {
       setIsValidNumPlayers(true);
     } else {
       setIsValidNumPlayers(false);

--- a/src/StartScreen.tsx
+++ b/src/StartScreen.tsx
@@ -11,7 +11,7 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
   const handleNumPlayersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     const num = parseInt(value, 10);
-    if (!isNaN(num) && num > 0 && num <= 20) {
+    if (!isNaN(num) && num >= 1 && num <= 20) {
       setIsValidNumPlayers(true);
     } else {
       setIsValidNumPlayers(false);
@@ -30,7 +30,7 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         <h1 className="title">Pictophone</h1>
       </div>
       <label htmlFor="num-players-input" className="num-players-label">
-        Number of players (0 to 20):
+        Number of players (1 to 20):
       </label>
       <input
         id="num-players-input"
@@ -39,6 +39,8 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         onChange={handleNumPlayersChange}
         placeholder="Enter number of players"
         className="num-players-input"
+        min="1"
+        max="20"
       />
       <button
         onClick={handleStartGame}

--- a/src/StartScreen.tsx
+++ b/src/StartScreen.tsx
@@ -39,8 +39,8 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         onChange={handleNumPlayersChange}
         placeholder="Enter number of players"
         className="num-players-input"
-        min="1"
-        max="20"
+        min={MIN_PLAYERS}
+        max={MAX_PLAYERS}
       />
       <button
         onClick={handleStartGame}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const MIN_PLAYERS = 1;
+export const MAX_PLAYERS = 20;


### PR DESCRIPTION
## Summary
- clarify label for minimum players
- enforce the same range in validation and HTML attributes

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd295b2d4832e886f73d56495c9eb